### PR TITLE
Make operator filter attribute not mandatory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,9 +9,12 @@ Backwards-compatible changes increment the minor version number only.
 Version 0.3.0
 -------------
 
-Released 2017-05-16
+Released 2017-05-22
 
 * Adds support for boolean functions within filters
+* Adds the possibility of supplying a single dictionary as filters when
+only one filter is provided
+* Makes the `op` filter attribute optional: `==` is the default operator
 
 Version 0.2.0
 -------------

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ following format:
         {'field': 'field_2_name', 'op': '!=', 'value': 'field_2_value'},
         # ...
     ]
-    
+
 Optionally, if there is only one filter, the containing list may be omitted:
 
 .. code-block:: python
@@ -111,7 +111,7 @@ Optionally, if there is only one filter, the containing list may be omitted:
 
 Where ``field`` is the name of the field that will be filtered using the
 operator provided in ``op`` (optional, defaults to `==`) and the
-provided ``value`` (optional depending on the operator).
+provided ``value`` (optional, depending on the operator).
 
 This is the list of operators that can be used:
 
@@ -151,9 +151,9 @@ Boolean Functions
         }
     ]
 
- 
+
 Note: ``or`` and ``and`` must reference a list of at least one element. ``not`` must reference a list of exactly one element.
- 
+
 Sort format
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -104,8 +104,8 @@ following format:
     ]
 
 Where ``field`` is the name of the field that will be filtered using the
-operator provided in ``op`` and (optionally, depending on the operator)
-the provided ``value``.
+operator provided in ``op`` (optional, defaults to `==`) and the
+provided ``value`` (optional depending on the operator).
 
 This is the list of operators that can be used:
 

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -45,7 +45,7 @@ class Operator(object):
         'not_in': lambda f, a: ~f.in_(a),
     }
 
-    def __init__(self, operator):
+    def __init__(self, operator='=='):
         if operator is None:
             operator = '=='
 

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -29,6 +29,9 @@ class Operator(object):
     }
 
     def __init__(self, operator):
+        if operator is None:
+            operator = '=='
+
         if operator not in self.OPERATORS:
             raise BadFilterFormat('Operator `{}` not valid.'.format(operator))
 
@@ -42,18 +45,15 @@ class Filter(object):
     def __init__(self, filter_, models):
         try:
             field_name = filter_['field']
-            op = filter_['op']
         except KeyError:
-            raise BadFilterFormat(
-                '`field` and `op` are mandatory filter attributes.'
-            )
+            raise BadFilterFormat('`field` is a mandatory filter attribute.')
         except TypeError:
             raise BadFilterFormat(
                 'Filter `{}` should be a dictionary.'.format(filter_)
             )
 
         self.field = Field(models, field_name)
-        self.operator = Operator(op)
+        self.operator = Operator(filter_.get('op'))
         self.value = filter_.get('value')
         self.value_present = True if 'value' in filter_ else False
 

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -45,7 +45,7 @@ class Operator(object):
         'not_in': lambda f, a: ~f.in_(a),
     }
 
-    def __init__(self, operator='=='):
+    def __init__(self, operator=None):
         if not operator:
             operator = '=='
 

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -46,7 +46,7 @@ class Operator(object):
     }
 
     def __init__(self, operator='=='):
-        if operator is None:
+        if not operator:
             operator = '=='
 
         if operator not in self.OPERATORS:

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -113,12 +113,14 @@ def _build_sqlalchemy_filters(filterdef, models):
                 if boolean_function.only_one_arg and len(fn_args) != 1:
                     raise BadFilterFormat(
                         '`{}` must have one argument'.format(
-                            boolean_function.key)
+                            boolean_function.key
+                        )
                     )
                 if not boolean_function.only_one_arg and len(fn_args) < 1:
                     raise BadFilterFormat(
                         '`{}` must have one or more arguments'.format(
-                            boolean_function.key)
+                            boolean_function.key
+                        )
                     )
                 return [
                     boolean_function.sqlalchemy_fn(


### PR DESCRIPTION
- Make `op` filter attribute optional.
- It will default to `==` if not provided.

@iky here you have the improvement that you suggested. cc @mattbennett 