### PR TITLE
Load spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Then we can apply filters to that ``query`` object (multiple times):
 
     # `query` should be a SQLAlchemy query object
 
-    filters = [{'field': 'name', 'op': '==', 'value': 'name_1'}]
-    filtered_query = apply_filters(query, filters)
+    filter_spec = [{'field': 'name', 'op': '==', 'value': 'name_1'}]
+    filtered_query = apply_filters(query, filter_spec)
 
     more_filters = [{'field': 'foo_id', 'op': 'is_not_null'}]
     filtered_query = apply_filters(filtered_query, more_filters)
@@ -67,11 +67,11 @@ It is also possible to filter queries that contain multiple models, including jo
 
     query = session.query(Foo).join(Bar)
 
-    filters = [
+    filter_spec = [
         {'model': 'Foo', field': 'name', 'op': '==', 'value': 'name_1'},
         {'model': 'Bar', field': 'count', 'op': '>=', 'value': 5},
     ]
-    filtered_query = apply_filters(query, filters)
+    filtered_query = apply_filters(query, filter_spec)
 
     result = filtered_query.all()
 
@@ -94,11 +94,11 @@ the `apply_loads` function:
 .. code-block:: python
 
     query = session.query(Foo, Bar).join(Bar)
-    loads = [
+    load_spec = [
         {'model': 'Foo', 'fields': ['name']},
         {'model': 'Bar', 'fields': ['count']}
     ]
-    query = apply_loads(query)  # will load only Foo.name and Bar.count
+    query = apply_loads(query, load_spec)  # will load only Foo.name and Bar.count
 
 
 The effect of the `apply_loads` function is to _defer_ the load of any other fields to when/if they're accessed, rather than loading them when the query is executed. It only applies to fields that would be loaded during normal query execution.
@@ -112,11 +112,11 @@ The default SQLAlchemy join is lazy, meaning that columns from the joined table 
 .. code-block:: python
 
     query = session.query(Foo).join(Bar)
-    loads = [
+    load_spec = [
         {'model': 'Foo', 'fields': ['name']}
         {'model': 'Bar', 'fields': ['count']}  # ignored
     ]
-    query = apply_loads(query)  # will load only Foo.name
+    query = apply_loads(query, load_spec)  # will load only Foo.name
 
 
 `apply_loads` cannot be applied to columns that are loaded as `joined eager loads <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#joined-eager-loading>`_. This is because a joined eager load does not add the joined model to the original query, as explained `here <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#the-zen-of-joined-eager-loading>`_
@@ -126,11 +126,11 @@ The following would produce an error:
 .. code-block:: python
 
     query = session.query(Foo).options(joinedload(Bar))
-    loads = [
+    load_spec = [
         {'model': 'Foo', 'fields': ['name']}
         {'model': 'Bar', 'fields': ['count']}  # invalid
     ]
-    query = apply_loads(query)  # error! query does not contain model Bar
+    query = apply_loads(query, load_spec)  # error! query does not contain model Bar
 
 
 If you wish to perform a joined load with restricted columns, you must specify the columns as part of the joined load, rather than with `apply_loads`:
@@ -138,10 +138,10 @@ If you wish to perform a joined load with restricted columns, you must specify t
 .. code-block:: python
 
     query = session.query(Foo).options(joinedload(Bar).load_only('count'))
-    loads = [
+    load_spec = [
         {'model': 'Foo', 'fields': ['name']}
     ]
-    query = apply_loads(query)  # will load ony Foo.name and Bar.count
+    query = apply_loads(query. load_spec)  # will load ony Foo.name and Bar.count
 
 
 Sort
@@ -153,11 +153,11 @@ Sort
 
     # `query` should be a SQLAlchemy query object
 
-    order_by = [
+    sort_spec = [
         {'model': 'Foo', field': 'name', 'direction': 'asc'},
         {'model': 'Bar', field': 'id', 'direction': 'desc'},
     ]
-    sorted_query = apply_sort(query, order_by)
+    sorted_query = apply_sort(query, sort_spec)
 
     result = sorted_query.all()
 
@@ -190,7 +190,7 @@ following format:
 
 .. code-block:: python
 
-    filters = [
+    filter_spec = [
         {'model': 'model_name', 'field': 'field_name', 'op': '==', 'value': 'field_value'},
         {'model': 'model_name', 'field': 'field_2_name', 'op': '!=', 'value': 'field_2_value'},
         # ...
@@ -202,7 +202,7 @@ If there is only one filter, the containing list may be omitted:
 
 .. code-block:: python
 
-    filters = {'field': 'field_name', 'op': '==', 'value': 'field_value'}
+    filter_spec = {'field': 'field_name', 'op': '==', 'value': 'field_value'}
 
 Where ``field`` is the name of the field that will be filtered using the
 operator provided in ``op`` (optional, defaults to `==`) and the
@@ -224,11 +224,11 @@ This is the list of operators that can be used:
 
 Boolean Functions
 *****************
-``and``, ``or``, and ``not`` functions can be used and nested within the filter definition:
+``and``, ``or``, and ``not`` functions can be used and nested within the filter specification:
 
 .. code-block:: python
 
-    filters = [
+    filter_spec = [
         {
             'or': [
                 {
@@ -257,7 +257,7 @@ applied sequentially:
 
 .. code-block:: python
 
-    order_by = [
+    sort_spec = [
         {'model': 'Foo', 'field': 'name', 'direction': 'asc'},
         {'model': 'Bar', 'field': 'id', 'direction': 'desc'},
         # ...

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 SQLAlchemy-filters
 ==================
 
-ADD LOAD SPEC DOCS inc note about joibedload
-FIX TYPOS IN DOCS!
-
 .. pull-quote::
 
     Filter, sort and paginate SQLAlchemy query objects.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 SQLAlchemy-filters
 ==================
 
+ADD LOAD SPEC DOCS inc note about joibedload
+FIX TYPOS IN DOCS!
+
 .. pull-quote::
 
     Filter, sort and paginate SQLAlchemy query objects.
@@ -82,6 +85,65 @@ Note that we can also apply filters to queries defined by fields or functions:
     query_alt_2 = session.query(func.count(Foo.id))
 
 
+Restricted Loads
+----------------
+
+You can restrict the fields that SQLAlchemy loads from the database by using
+the `apply_loads` function:
+
+.. code-block:: python
+
+    query = session.query(Foo, Bar).join(Bar)
+    loads = [
+        {'model': 'Foo', 'fields': ['name']},
+        {'model': 'Bar', 'fields': ['count']}
+    ]
+    query = apply_loads(query)  # will load only Foo.name and Bar.count
+
+
+The effect of the `apply_loads` function is to _defer_ the load of any other fields to when/if they're accessed, rather than loading them when the query is executed. It only applies to fields that would be loaded during normal query execution.
+
+
+Effect on joined queries
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default SQLAlchemy join is lazy, meaning that columns from the joined table are loaded only when required. Therefore `apply_loads` has limited effect in the following scenario:
+
+.. code-block:: python
+
+    query = session.query(Foo).join(Bar)
+    loads = [
+        {'model': 'Foo', 'fields': ['name']}
+        {'model': 'Bar', 'fields': ['count']}  # ignored
+    ]
+    query = apply_loads(query)  # will load only Foo.name
+
+
+`apply_loads` cannot be applied to columns that are loaded as `joined eager loads <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#joined-eager-loading>`_. This is because a joined eager load does not add the joined model to the original query, as explained `here <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#the-zen-of-joined-eager-loading>`_
+
+The following would produce an error:
+
+.. code-block:: python
+
+    query = session.query(Foo).options(joinedload(Bar))
+    loads = [
+        {'model': 'Foo', 'fields': ['name']}
+        {'model': 'Bar', 'fields': ['count']}  # invalid
+    ]
+    query = apply_loads(query)  # error! query does not contain model Bar
+
+
+If you wish to perform a joined load with restricted columns, you must specify the columns as part of the joined load, rather than with `apply_loads`:
+
+.. code-block:: python
+
+    query = session.query(Foo).options(joinedload(Bar).load_only('count'))
+    loads = [
+        {'model': 'Foo', 'fields': ['name']}
+    ]
+    query = apply_loads(query)  # will load ony Foo.name and Bar.count
+
+
 Sort
 ----
 
@@ -130,7 +192,7 @@ following format:
 
     filters = [
         {'model': 'model_name', 'field': 'field_name', 'op': '==', 'value': 'field_value'},
-        {{'model': 'model_name', 'field': 'field_2_name', 'op': '!=', 'value': 'field_2_value'},
+        {'model': 'model_name', 'field': 'field_2_name', 'op': '!=', 'value': 'field_2_value'},
         # ...
     ]
 
@@ -197,7 +259,7 @@ applied sequentially:
 
     order_by = [
         {'model': 'Foo', 'field': 'name', 'direction': 'asc'},
-        {'model': 'Bar', field': 'id', 'direction': 'desc'},
+        {'model': 'Bar', 'field': 'id', 'direction': 'desc'},
         # ...
     ]
 

--- a/sqlalchemy_filters/__init__.py
+++ b/sqlalchemy_filters/__init__.py
@@ -2,6 +2,5 @@
 
 from .filters import apply_filters  # noqa: F401
 from .loads import apply_loads  # noqa: F401
-from .models import get_query_models  # noqa: F401
 from .pagination import apply_pagination  # noqa: F401
 from .sorting import apply_sort  # noqa: F401

--- a/sqlalchemy_filters/__init__.py
+++ b/sqlalchemy_filters/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .filters import apply_filters  # noqa: F401
+from .loads import apply_loads  # noqa: F401
 from .models import get_query_models  # noqa: F401
 from .pagination import apply_pagination  # noqa: F401
 from .sorting import apply_sort  # noqa: F401

--- a/sqlalchemy_filters/exceptions.py
+++ b/sqlalchemy_filters/exceptions.py
@@ -9,6 +9,10 @@ class BadSortFormat(Exception):
     pass
 
 
+class BadLoadFormat(Exception):
+    pass
+
+
 class FieldNotFound(Exception):
     pass
 

--- a/sqlalchemy_filters/exceptions.py
+++ b/sqlalchemy_filters/exceptions.py
@@ -13,6 +13,10 @@ class BadLoadFormat(Exception):
     pass
 
 
+class BadSpec(Exception):
+    pass
+
+
 class FieldNotFound(Exception):
     pass
 

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -153,6 +153,26 @@ def apply_filters(query, filter_spec):
         the necesary information to create a filter to be applied to the
         query.
 
+        Example::
+
+            filter_spec = [
+                {'model': 'Foo', 'field': 'name', 'op': '==', 'value': 'foo'},
+            ]
+
+        If the query being modified refers to a single model, the `model` key
+        may be omitted from the filter spec.
+
+        Filters may be combined using boolean functions.
+
+        Example:
+
+            filter_spec = {
+                'or': [
+                    {'model': 'Foo', 'field': 'id', 'op': '==', 'value': '1'},
+                    {'model': 'Bar', 'field': 'id', 'op': '==', 'value': '2'},
+                ]
+            }
+
     :returns:
         The :class:`sqlalchemy.orm.Query` instance after all the filters
         have been applied.

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -6,7 +6,7 @@ from itertools import chain
 from six import string_types
 from sqlalchemy import and_, or_, not_
 
-from .exceptions import BadSpec, BadFilterFormat
+from .exceptions import BadFilterFormat
 from .models import Field, get_model_from_spec
 
 
@@ -69,10 +69,7 @@ class Filter(object):
                 'Filter spec `{}` should be a dictionary.'.format(filter_spec)
             )
 
-        try:
-            model = get_model_from_spec(filter_spec, query)
-        except BadSpec as exc:
-            raise BadFilterFormat(str(exc)) from exc
+        model = get_model_from_spec(filter_spec, query)
 
         self.field = Field(model, field_name)
         self.operator = Operator(filter_spec.get('op'))

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -91,8 +91,17 @@ class Filter(object):
             return function(field, self.value)
 
 
+def _is_iterable_filter(filter_spec):
+    """ `filter_spec` may be a list of nested filter specs, or a dict.
+    """
+    return (
+        isinstance(filter_spec, Iterable) and
+        not isinstance(filter_spec, (string_types, dict))
+    )
+
+
 def _build_sqlalchemy_filters(filter_spec, query):
-    """ Recursively parse `filter_spec` into sqlalchemy filter arguments """
+    """ Recursively process `filter_spec` """
 
     if _is_iterable_filter(filter_spec):
         return list(chain.from_iterable(
@@ -100,10 +109,10 @@ def _build_sqlalchemy_filters(filter_spec, query):
         ))
 
     if isinstance(filter_spec, dict):
-        # Check if filterdef defines a boolean function.
+        # Check if filter spec defines a boolean function.
         for boolean_function in BOOLEAN_FUNCTIONS:
             if boolean_function.key in filter_spec:
-                # The filterdef is for a boolean-function
+                # The filter spec is for a boolean-function
                 # Get the function argument definitions and validate
                 fn_args = filter_spec[boolean_function.key]
 
@@ -131,13 +140,6 @@ def _build_sqlalchemy_filters(filter_spec, query):
                 ]
 
     return [Filter(filter_spec, query).format_for_sqlalchemy()]
-
-
-def _is_iterable_filter(filterdef):
-    return (
-        isinstance(filterdef, Iterable) and
-        not isinstance(filterdef, (string_types, dict))
-    )
 
 
 def apply_filters(query, filter_spec):

--- a/sqlalchemy_filters/loads.py
+++ b/sqlalchemy_filters/loads.py
@@ -1,0 +1,71 @@
+from sqlalchemy.orm import Load
+
+from .exceptions import BadQuery, BadLoadFormat
+from .models import get_query_models
+
+
+class LoadOnly(object):
+
+    def __init__(self, value, models):
+        try:
+            self.field_names = value['fields']
+        except KeyError:
+            raise BadLoadFormat(
+                '`fields` is a mandatory attribute.'
+            )
+        except TypeError:
+            raise BadLoadFormat(
+                'Value `{}` should be a dictionary.'.format(value)
+            )
+
+        model_name = value.get('model')
+        if model_name is not None:
+            models = [v for (k, v) in models.items() if k == model_name]
+            if not models:
+                raise BadLoadFormat(
+                    'The query does not contain model `{}`.'.format(model_name)
+                )
+            model = models[0]
+        else:
+            if len(models) == 1:
+                model = list(models.values())[0]
+            else:
+                raise BadLoadFormat(
+                    "Ambiguous field. Please specify a model."
+                )
+
+        self.model = model
+
+    def format_for_sqlalchemy(self):
+        return Load(self.model).load_only(*self.field_names)
+
+
+def apply_loads(query, spec):
+    """Apply load restrictions to a :class:`sqlalchemy.orm.Query` instance.
+
+    :param spec:
+        A list of dictionaries, where each item contains the fields to load
+        for each model.
+
+        Example::
+
+            spec = [
+                {'model': 'Foo', fields': ['id', 'name']},
+                {'model': 'Bar', 'fields': ['name']},
+            ]
+
+    :returns:
+        The :class:`sqlalchemy.orm.Query` instance after the load restrictions
+        have been applied.
+    """
+    models = get_query_models(query)
+    if not models:
+        raise BadQuery('The query does not contain any models.')
+
+    sqlalchemy_loads = [
+        LoadOnly(value, models).format_for_sqlalchemy() for value in spec
+    ]
+    if sqlalchemy_loads:
+        query = query.options(*sqlalchemy_loads)
+
+    return query

--- a/sqlalchemy_filters/loads.py
+++ b/sqlalchemy_filters/loads.py
@@ -47,6 +47,15 @@ def apply_loads(query, load_spec):
         The :class:`sqlalchemy.orm.Query` instance after the load restrictions
         have been applied.
     """
+    if (
+        isinstance(load_spec, list) and
+        all(map(lambda item: isinstance(item, str), load_spec))
+    ):
+        load_spec = {'fields': load_spec}
+
+    if isinstance(load_spec, dict):
+        load_spec = [load_spec]
+
     sqlalchemy_loads = [
         LoadOnly(item, query).format_for_sqlalchemy() for item in load_spec
     ]

--- a/sqlalchemy_filters/loads.py
+++ b/sqlalchemy_filters/loads.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Load
 
-from .exceptions import BadSpec, BadLoadFormat
+from .exceptions import BadLoadFormat
 from .models import Field, get_model_from_spec
 
 
@@ -18,13 +18,10 @@ class LoadOnly(object):
                 'Load spec `{}` should be a dictionary.'.format(load_spec)
             )
 
-        try:
-            model = get_model_from_spec(load_spec, query)
-        except BadSpec as exc:
-            raise BadLoadFormat(str(exc)) from exc
-
-        self.model = model
-        self.fields = [Field(model, field_name) for field_name in field_names]
+        self.model = get_model_from_spec(load_spec, query)
+        self.fields = [
+            Field(self.model, field_name) for field_name in field_names
+        ]
 
     def format_for_sqlalchemy(self):
         return Load(self.model).load_only(

--- a/sqlalchemy_filters/loads.py
+++ b/sqlalchemy_filters/loads.py
@@ -43,6 +43,12 @@ def apply_loads(query, load_spec):
                 {'model': 'Bar', 'fields': ['name']},
             ]
 
+        If the query being modified refers to a single model, the `model` key
+        may be omitted from the load spec. The following shorthand form is
+        also accepted when the model can be inferred::
+
+            load_spec = ['id', 'name']
+
     :returns:
         The :class:`sqlalchemy.orm.Query` instance after the load restrictions
         have been applied.

--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy.inspection import inspect
 
-from .exceptions import FieldNotFound
+from .exceptions import BadQuery, FieldNotFound, BadSpec
 
 
 class Field(object):
@@ -33,3 +33,50 @@ def get_query_models(query):
     return {
         model.__name__: model for model in models
     }
+
+
+def get_model_from_spec(spec, query):
+    """ Determine the model to which a spec applies on a given query.
+
+    A spec that does not specify a model may be applied to a query that
+    contains a single model. Otherwise the spec must specify the model to
+    which it applies, and that model must be present in the query.
+
+    :param query:
+        A :class:`sqlalchemy.orm.Query` instance.
+
+    :param spec:
+        A dictionary that may or may not contain a model name to resolve
+        against the query.
+
+    :returns:
+        A model instance.
+
+    :raise BadSpec:
+        If the spec is ambiguous or refers to a model not in the query.
+
+    :raise BadQuery:
+        If the query contains no models.
+
+    """
+    models = get_query_models(query)
+    if not models:
+        raise BadQuery('The query does not contain any models.')
+
+    model_name = spec.get('model')
+    if model_name is not None:
+        models = [v for (k, v) in models.items() if k == model_name]
+        if not models:
+            raise BadSpec(
+                'The query does not contain model `{}`.'.format(model_name)
+            )
+        model = models[0]
+    else:
+        if len(models) == 1:
+            model = list(models.values())[0]
+        else:
+            raise BadSpec(
+                "Ambiguous spec. Please specify a model."
+            )
+
+    return model

--- a/sqlalchemy_filters/sorting.py
+++ b/sqlalchemy_filters/sorting.py
@@ -50,9 +50,12 @@ def apply_sort(query, sort_spec):
         Example::
 
             sort_spec = [
-                {'field': 'name', 'direction': 'asc'},
-                {'field': 'id', 'direction': 'desc'},
+                {'model': 'Foo', 'field': 'name', 'direction': 'asc'},
+                {'model': 'Bar', 'field': 'id', 'direction': 'desc'},
             ]
+
+        If the query being modified refers to a single model, the `model` key
+        may be omitted from the sort spec.
 
     :returns:
         The :class:`sqlalchemy.orm.Query` instance after the provided

--- a/sqlalchemy_filters/sorting.py
+++ b/sqlalchemy_filters/sorting.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .exceptions import BadSpec, BadSortFormat
+from .exceptions import BadSortFormat
 from .models import Field, get_model_from_spec
 
 
@@ -26,10 +26,7 @@ class Sort(object):
         if direction not in [SORT_ASCENDING, SORT_DESCENDING]:
             raise BadSortFormat('Direction `{}` not valid.'.format(direction))
 
-        try:
-            model = get_model_from_spec(sort_spec, query)
-        except BadSpec as exc:
-            raise BadSortFormat(str(exc)) from exc
+        model = get_model_from_spec(sort_spec, query)
 
         self.field = Field(model, field_name)
         self.direction = direction

--- a/sqlalchemy_filters/sorting.py
+++ b/sqlalchemy_filters/sorting.py
@@ -58,6 +58,9 @@ def apply_sort(query, sort_spec):
         The :class:`sqlalchemy.orm.Query` instance after the provided
         sorting has been applied.
     """
+    if isinstance(sort_spec, dict):
+        sort_spec = [sort_spec]
+
     sqlalchemy_order_by = [
         Sort(item, query).format_for_sqlalchemy() for item in sort_spec
     ]

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -112,7 +112,7 @@ class TestProvidedModels:
         with pytest.raises(BadFilterFormat) as err:
             apply_filters(query, filters)
 
-        assert 'Ambiguous filter. Please specify a model.' == err.value.args[0]
+        assert 'Ambiguous spec. Please specify a model.' == err.value.args[0]
 
 
 class TestProvidedFilters:
@@ -133,7 +133,7 @@ class TestProvidedFilters:
         with pytest.raises(BadFilterFormat) as err:
             apply_filters(query, filters)
 
-        expected_error = 'Filter `{}` should be a dictionary.'.format(
+        expected_error = 'Filter spec `{}` should be a dictionary.'.format(
             filter_
         )
         assert expected_error == err.value.args[0]

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -5,9 +5,8 @@ import datetime
 import pytest
 from sqlalchemy import func
 from sqlalchemy_filters import apply_filters
-from sqlalchemy_filters.exceptions import (
-    BadFilterFormat, FieldNotFound, BadQuery
-)
+from sqlalchemy_filters.exceptions import BadFilterFormat, FieldNotFound
+
 from test.models import Bar, Qux
 
 
@@ -46,76 +45,7 @@ def multiple_quxs_inserted(session):
     session.commit()
 
 
-class TestProvidedModels:
-
-    def test_query_with_no_models(self, session):
-        query = session.query()
-        filters = [{'field': 'name', 'op': '==', 'value': 'name_1'}]
-
-        with pytest.raises(BadQuery) as err:
-            apply_filters(query, filters)
-
-        assert 'The query does not contain any models.' == err.value.args[0]
-
-    @pytest.mark.usefixtures('multiple_bars_inserted')
-    def test_query_with_named_model(self, session):
-        query = session.query(Bar)
-        filters = [
-            {'model': 'Bar', 'field': 'name', 'op': '==', 'value': 'name_1'}
-        ]
-
-        filtered_query = apply_filters(query, filters)
-        result = filtered_query.all()
-
-        assert len(result) == 2
-        assert result[0].id == 1
-        assert result[1].id == 3
-
-    def test_query_with_missing_named_model(self, session):
-        query = session.query(Bar)
-        filters = [
-            {'model': 'Buz', 'field': 'name', 'op': '==', 'value': 'name_1'}
-        ]
-
-        with pytest.raises(BadFilterFormat) as err:
-            apply_filters(query, filters)
-
-        assert 'The query does not contain model `Buz`.' == err.value.args[0]
-
-    @pytest.mark.usefixtures('multiple_bars_inserted')
-    @pytest.mark.usefixtures('multiple_quxs_inserted')
-    def test_multiple_models(self, session):
-        query = session.query(Bar, Qux)
-        filters = [
-            {'model': 'Bar', 'field': 'name', 'op': '==', 'value': 'name_1'},
-            {'model': 'Qux', 'field': 'name', 'op': '==', 'value': 'name_1'},
-        ]
-
-        filtered_query = apply_filters(query, filters)
-        result = filtered_query.all()
-
-        assert len(result) == 4
-        bars, quxs = zip(*result)
-        assert set(map(type, bars)) == {Bar}
-        assert {bar.id for bar in bars} == {1, 3}
-        assert {bar.name for bar in bars} == {"name_1"}
-        assert set(map(type, quxs)) == {Qux}
-        assert {qux.id for qux in quxs} == {1, 3}
-        assert {qux.name for qux in quxs} == {"name_1"}
-
-    def test_multiple_models_ambiquous_query(self, session):
-        query = session.query(Bar, Qux)
-        filters = [
-            {'field': 'name', 'op': '==', 'value': 'name_1'}
-        ]
-
-        with pytest.raises(BadFilterFormat) as err:
-            apply_filters(query, filters)
-
-        assert 'Ambiguous spec. Please specify a model.' == err.value.args[0]
-
-
-class TestProvidedFilters:
+class TestFiltersNotApplied:
 
     def test_no_filters_provided(self, session):
         query = session.query(Bar)
@@ -209,6 +139,31 @@ class TestProvidedFilters:
             )
         )
         assert expected_error == err.value.args[0]
+
+
+class TestMultipleModels:
+
+    # TODO: multi-model should be tested for each filter type
+    @pytest.mark.usefixtures('multiple_bars_inserted')
+    @pytest.mark.usefixtures('multiple_quxs_inserted')
+    def test_multiple_models(self, session):
+        query = session.query(Bar, Qux)
+        filters = [
+            {'model': 'Bar', 'field': 'name', 'op': '==', 'value': 'name_1'},
+            {'model': 'Qux', 'field': 'name', 'op': '==', 'value': 'name_1'},
+        ]
+
+        filtered_query = apply_filters(query, filters)
+        result = filtered_query.all()
+
+        assert len(result) == 4
+        bars, quxs = zip(*result)
+        assert set(map(type, bars)) == {Bar}
+        assert {bar.id for bar in bars} == {1, 3}
+        assert {bar.name for bar in bars} == {"name_1"}
+        assert set(map(type, quxs)) == {Qux}
+        assert {qux.id for qux in quxs} == {1, 3}
+        assert {qux.name for qux in quxs} == {"name_1"}
 
 
 class TestApplyIsNullFilter:

--- a/test/interface/test_loads.py
+++ b/test/interface/test_loads.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from sqlalchemy_filters import apply_loads
+from test.models import Foo, Bar
+
+
+@pytest.fixture
+def multiple_bars_inserted(session):
+    bar_1 = Bar(id=1, name='name_1', count=5)
+    bar_2 = Bar(id=2, name='name_2', count=10)
+    bar_3 = Bar(id=3, name='name_1', count=None)
+    bar_4 = Bar(id=4, name='name_4', count=15)
+    session.add_all([bar_1, bar_2, bar_3, bar_4])
+    session.commit()
+
+
+@pytest.fixture
+def multiple_foos_inserted(multiple_bars_inserted, session):
+    foo_1 = Foo(id=1, name='name_1', count=5, bar_id=1)
+    foo_2 = Foo(id=2, name='name_2', count=10, bar_id=2)
+    foo_3 = Foo(id=3, name='name_1', count=None, bar_id=3)
+    foo_4 = Foo(id=4, name='name_4', count=15, bar_id=4)
+    session.add_all([foo_1, foo_2, foo_3, foo_4])
+    session.commit()
+
+
+class TestFieldsApplied(object):
+
+    @pytest.mark.usefixtures('multiple_bars_inserted')
+    def test_single_value(self, session):
+
+        query = session.query(Bar)
+        loads = [
+            {'fields': ['name']}
+        ]
+
+        restricted_query = apply_loads(query, loads)
+
+        expected = (
+            "SELECT bar.id AS bar_id, bar.name AS bar_name \n"
+            "FROM bar"
+        )
+        assert str(restricted_query) == expected
+
+    @pytest.mark.usefixtures('multiple_foos_inserted')
+    def test_multiple_values_single_model(self, session):
+
+        query = session.query(Foo)
+        loads = [
+            {'fields': ['name', 'count']}
+        ]
+
+        restricted_query = apply_loads(query, loads)
+
+        expected = (
+            "SELECT foo.id AS foo_id, foo.name AS foo_name, "
+            "foo.count AS foo_count \n"
+            "FROM foo"
+        )
+        assert str(restricted_query) == expected
+
+    @pytest.mark.usefixtures('multiple_foos_inserted')
+    def test_multiple_values_multiple_models(self, session):
+
+        query = session.query(Foo, Bar)
+        loads = [
+            {'model': 'Foo', 'fields': ['count']},
+            {'model': 'Bar', 'fields': ['count']},
+        ]
+
+        restricted_query = apply_loads(query, loads)
+
+        expected = (
+            "SELECT foo.id AS foo_id, foo.count AS foo_count, "
+            "bar.id AS bar_id, bar.count AS bar_count \n"
+            "FROM foo, bar"
+        )
+        assert str(restricted_query) == expected
+
+    @pytest.mark.usefixtures('multiple_foos_inserted')
+    def test_multiple_values_multiple_models_joined(self, session):
+
+        query = session.query(Foo, Bar).join(Bar)
+        loads = [
+            {'model': 'Foo', 'fields': ['count']},
+            {'model': 'Bar', 'fields': ['count']},
+        ]
+
+        restricted_query = apply_loads(query, loads)
+
+        expected = (
+            "SELECT foo.id AS foo_id, foo.count AS foo_count, "
+            "bar.id AS bar_id, bar.count AS bar_count \n"
+            "FROM foo INNER JOIN bar ON bar.id = foo.bar_id"
+        )
+        assert str(restricted_query) == expected
+
+    @pytest.mark.usefixtures('multiple_foos_inserted')
+    def test_multiple_values_multiple_models_lazy_load(self, session):
+
+        query = session.query(Foo).join(Bar)
+        loads = [
+            {'model': 'Foo', 'fields': ['count']},
+            {'model': 'Bar', 'fields': ['count']},
+        ]
+
+        restricted_query = apply_loads(query, loads)
+
+        # Bar is lazily joined, so the second loads directive has no effect
+        expected = (
+            "SELECT foo.id AS foo_id, foo.count AS foo_count \n"
+            "FROM foo INNER JOIN bar ON bar.id = foo.bar_id"
+        )
+        assert str(restricted_query) == expected

--- a/test/interface/test_loads.py
+++ b/test/interface/test_loads.py
@@ -78,7 +78,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_bars_inserted')
     def test_single_value(self, session):
 
         query = session.query(Bar)
@@ -94,7 +93,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_multiple_values_single_model(self, session):
 
         query = session.query(Foo)
@@ -111,7 +109,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_multiple_values_multiple_models(self, session):
 
         query = session.query(Foo, Bar)
@@ -129,7 +126,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_multiple_values_multiple_models_joined(self, session, db_uri):
 
         query = session.query(Foo, Bar).join(Bar)
@@ -149,7 +145,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_multiple_values_multiple_models_lazy_load(self, session, db_uri):
 
         query = session.query(Foo).join(Bar)
@@ -169,7 +164,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_a_single_dict_can_be_supplied_as_load_spec(self, session):
 
         query = session.query(Foo)
@@ -184,7 +178,6 @@ class TestLoadsApplied(object):
         )
         assert str(restricted_query) == expected
 
-    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_a_list_of_fields_can_be_supplied_as_load_spec(self, session):
 
         query = session.query(Foo)

--- a/test/interface/test_models.py
+++ b/test/interface/test_models.py
@@ -1,7 +1,9 @@
+import pytest
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
-from sqlalchemy_filters import get_query_models
+from sqlalchemy_filters.exceptions import BadSpec, BadQuery
+from sqlalchemy_filters.models import get_query_models, get_model_from_spec
 from test.models import Bar, Foo, Qux
 
 
@@ -77,3 +79,40 @@ class TestGetQueryModels(object):
 
         # Bar is not added to the query since the joinedload is transparent
         assert {'Foo': Foo} == entities
+
+
+class TestGetModelFromSpec:
+
+    def test_query_with_no_models(self, session):
+        query = session.query()
+        spec = {'field': 'name', 'op': '==', 'value': 'name_1'}
+
+        with pytest.raises(BadQuery) as err:
+            get_model_from_spec(spec, query)
+
+        assert 'The query does not contain any models.' == err.value.args[0]
+
+    def test_query_with_named_model(self, session):
+        query = session.query(Bar)
+        spec = {'model': 'Bar'}
+
+        model = get_model_from_spec(spec, query)
+        assert model == Bar
+
+    def test_query_with_missing_named_model(self, session):
+        query = session.query(Bar)
+        spec = {'model': 'Buz'}
+
+        with pytest.raises(BadSpec) as err:
+            get_model_from_spec(spec, query)
+
+        assert 'The query does not contain model `Buz`.' == err.value.args[0]
+
+    def test_multiple_models_ambiquous_spec(self, session):
+        query = session.query(Bar, Qux)
+        spec = {'field': 'name', 'op': '==', 'value': 'name_1'}
+
+        with pytest.raises(BadSpec) as err:
+            get_model_from_spec(spec, query)
+
+        assert 'Ambiguous spec. Please specify a model.' == err.value.args[0]

--- a/test/interface/test_models.py
+++ b/test/interface/test_models.py
@@ -1,4 +1,6 @@
 from sqlalchemy import func
+from sqlalchemy.orm import joinedload
+
 from sqlalchemy_filters import get_query_models
 from test.models import Bar, Foo, Qux
 
@@ -67,3 +69,11 @@ class TestGetQueryModels(object):
         entities = get_query_models(query)
 
         assert {'Foo': Foo, 'Bar': Bar, 'Qux': Qux} == entities
+
+    def test_query_with_joinedload(self, session):
+        query = session.query(Foo).options(joinedload(Foo.bar))
+
+        entities = get_query_models(query)
+
+        # Bar is not added to the query since the joinedload is transparent
+        assert {'Foo': Foo} == entities

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -120,7 +120,7 @@ class TestProvidedModels(object):
         with pytest.raises(BadSortFormat) as err:
             apply_sort(query, order_by)
 
-        assert 'Ambiguous sort. Please specify a model.' == err.value.args[0]
+        assert 'Ambiguous spec. Please specify a model.' == err.value.args[0]
 
 
 class TestSortNotApplied(object):
@@ -141,7 +141,7 @@ class TestSortNotApplied(object):
         with pytest.raises(BadSortFormat) as err:
             apply_sort(query, order_by)
 
-        expected_error = 'Sort `{}` should be a dictionary.'.format(sort)
+        expected_error = 'Sort spec `{}` should be a dictionary.'.format(sort)
         assert expected_error == error_value(err)
 
     def test_field_not_provided(self, session):

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -196,3 +196,21 @@ class TestSortApplied(object):
         assert result[1].id == 1
         assert result[2].id == 4
         assert result[3].id == 2
+
+    @pytest.mark.usefixtures('multiple_bars_inserted')
+    def test_a_single_dict_can_be_supplied_as_sort_spec(self, session):
+        query = session.query(Bar)
+        sort_spec = {'field': 'name', 'direction': 'desc'}
+
+        sorted_query = apply_sort(query, sort_spec)
+        result = sorted_query.all()
+
+        assert len(result) == 8
+        assert result[0].id == 8
+        assert result[1].id == 4
+        assert result[2].id == 6
+        assert result[3].id == 2
+        assert result[4].id == 1
+        assert result[5].id == 3
+        assert result[6].id == 5
+        assert result[7].id == 7

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 
-from sqlalchemy_filters.exceptions import (
-    BadQuery, BadSortFormat, FieldNotFound
-)
+from sqlalchemy_filters.exceptions import BadSortFormat, FieldNotFound
 from sqlalchemy_filters.sorting import apply_sort
 from test import error_value
 from test.models import Bar, Qux

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -28,101 +28,6 @@ def multiple_bars_inserted(session):
     session.commit()
 
 
-class TestProvidedModels(object):
-
-    def test_query_with_no_models(self, session):
-        query = session.query()
-        order_by = [{'field': 'name', 'direction': 'asc'}]
-
-        with pytest.raises(BadQuery) as err:
-            apply_sort(query, order_by)
-
-        assert 'The query does not contain any models.' == error_value(err)
-
-    @pytest.mark.usefixtures('multiple_bars_inserted')
-    def test_query_with_named_model(self, session):
-        query = session.query(Bar)
-        order_by = [{'model': 'Bar', 'field': 'name', 'direction': 'asc'}]
-
-        sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
-
-        assert len(result) == 8
-        assert result[0].id == 1
-        assert result[1].id == 3
-        assert result[2].id == 5
-        assert result[3].id == 7
-        assert result[4].id == 2
-        assert result[5].id == 4
-        assert result[6].id == 6
-        assert result[7].id == 8
-
-    def test_query_with_missing_named_model(self, session):
-        query = session.query(Bar)
-        order_by = [{'model': 'Buz', 'field': 'name', 'direction': 'asc'}]
-
-        with pytest.raises(BadSortFormat) as err:
-            apply_sort(query, order_by)
-
-        assert 'The query does not contain model `Buz`.' == err.value.args[0]
-
-    def test_multiple_models(self, session):
-
-        bar_1 = Bar(id=1, name='name_1', count=5)
-        bar_2 = Bar(id=2, name='name_2', count=10)
-        bar_3 = Bar(id=3, name='name_1', count=None)
-        bar_4 = Bar(id=4, name='name_1', count=12)
-
-        qux_1 = Qux(
-            id=1, name='name_1', count=5,
-            created_at=datetime.date(2016, 7, 12),
-            execution_time=datetime.datetime(2016, 7, 12, 1, 5, 9)
-        )
-        qux_2 = Qux(
-            id=2, name='name_2', count=10,
-            created_at=datetime.date(2016, 7, 13),
-            execution_time=datetime.datetime(2016, 7, 13, 2, 5, 9)
-        )
-        qux_3 = Qux(
-            id=3, name='name_1', count=None,
-            created_at=None, execution_time=None
-        )
-        qux_4 = Qux(
-            id=4, name='name_1', count=15,
-            created_at=datetime.date(2016, 7, 14),
-            execution_time=datetime.datetime(2016, 7, 14, 3, 5, 9)
-        )
-
-        session.add_all(
-            [bar_1, bar_2, bar_3, bar_4, qux_1, qux_2, qux_3, qux_4]
-        )
-        session.commit()
-
-        query = session.query(Bar).join(Qux, Bar.id == Qux.id)
-        order_by = [
-            {'model': 'Bar', 'field': 'name', 'direction': 'asc'},
-            {'model': 'Qux', 'field': 'count', 'direction': 'asc'}
-        ]
-
-        sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
-
-        assert len(result) == 4
-        assert result[0].id == 3
-        assert result[1].id == 1
-        assert result[2].id == 4
-        assert result[3].id == 2
-
-    def test_multiple_models_ambiquous_query(self, session):
-        query = session.query(Bar, Qux)
-        order_by = [{'field': 'name', 'direction': 'asc'}]
-
-        with pytest.raises(BadSortFormat) as err:
-            apply_sort(query, order_by)
-
-        assert 'Ambiguous spec. Please specify a model.' == err.value.args[0]
-
-
 class TestSortNotApplied(object):
 
     def test_no_sort_provided(self, session):
@@ -246,3 +151,50 @@ class TestSortApplied(object):
         assert result[5].id == 6
         assert result[6].id == 4
         assert result[7].id == 8
+
+    def test_multiple_models(self, session):
+
+        bar_1 = Bar(id=1, name='name_1', count=5)
+        bar_2 = Bar(id=2, name='name_2', count=10)
+        bar_3 = Bar(id=3, name='name_1', count=None)
+        bar_4 = Bar(id=4, name='name_1', count=12)
+
+        qux_1 = Qux(
+            id=1, name='name_1', count=5,
+            created_at=datetime.date(2016, 7, 12),
+            execution_time=datetime.datetime(2016, 7, 12, 1, 5, 9)
+        )
+        qux_2 = Qux(
+            id=2, name='name_2', count=10,
+            created_at=datetime.date(2016, 7, 13),
+            execution_time=datetime.datetime(2016, 7, 13, 2, 5, 9)
+        )
+        qux_3 = Qux(
+            id=3, name='name_1', count=None,
+            created_at=None, execution_time=None
+        )
+        qux_4 = Qux(
+            id=4, name='name_1', count=15,
+            created_at=datetime.date(2016, 7, 14),
+            execution_time=datetime.datetime(2016, 7, 14, 3, 5, 9)
+        )
+
+        session.add_all(
+            [bar_1, bar_2, bar_3, bar_4, qux_1, qux_2, qux_3, qux_4]
+        )
+        session.commit()
+
+        query = session.query(Bar).join(Qux, Bar.id == Qux.id)
+        order_by = [
+            {'model': 'Bar', 'field': 'name', 'direction': 'asc'},
+            {'model': 'Qux', 'field': 'count', 'direction': 'asc'}
+        ]
+
+        sorted_query = apply_sort(query, order_by)
+        result = sorted_query.all()
+
+        assert len(result) == 4
+        assert result[0].id == 3
+        assert result[1].id == 1
+        assert result[2].id == 4
+        assert result[3].id == 2


### PR DESCRIPTION
Adds the ability to specify fields to fetch from the database, e.g.
 
``` python
load_spec = [
    {'model': 'Foo', 'fields': ['a','b']},
    {'model': 'Bar', 'fields': ['c,'d']},
]
query = apply_loads(query, load_spec)
```

Includes from DRYing out of the logic to fetch models from a "spec" (filter, sort or load)