### PR TITLE
Fix header characters in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ This is the list of operators that can be used:
 - ``not_in``
 
 Boolean Functions
-*****************
+^^^^^^^^^^^^^^^^^
 ``and``, ``or``, and ``not`` functions can be used and nested within the filter specification:
 
 .. code-block:: python


### PR DESCRIPTION
GitHub needs the title characters to be consistent to be able to render the README.